### PR TITLE
Allow manual source selection

### DIFF
--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -46,6 +46,7 @@ local follow_safezone_sensitivity = 10
 local use_follow_auto_lock = false
 local zoom_value = 2
 local zoom_speed = 0.1
+local allow_all_sources = false
 local use_monitor_override = false
 local monitor_override_x = 0
 local monitor_override_y = 0
@@ -201,9 +202,6 @@ function get_monitor_info(source)
                 if info.width == 0 and info.height == 0 then
                     info = nil
                 end
-            else
-                log("Warning: Could not find display name.\n" ..
-                    "Try using the 'Set manual monitor position' option and adding override values")
             end
         end
 
@@ -215,8 +213,15 @@ function get_monitor_info(source)
             x = monitor_override_x,
             y = monitor_override_y,
             width = monitor_override_w,
-            height = monitor_override_h
+            height = monitor_override_h,
+            scale_x = monitor_override_sx,
+            scale_y = monitor_override_sy
         }
+    end
+
+    if not info then
+        log("WARNING: Could not auto calculate zoom source position and size.\n" ..
+            "         Try using the 'Set manual source position' option and adding override values")
     end
 
     return info
@@ -309,7 +314,7 @@ function refresh_sceneitem(find_newest)
                             -- Check if the current scene has the target scene item
                             local found = obs.obs_scene_find_source(s, source_name)
                             if found ~= nil then
-                                log("Found sceneitem")
+                                log("Found sceneitem '" .. source_name .. "'")
                                 obs.obs_sceneitem_addref(found)
                                 return found
                             end
@@ -340,7 +345,8 @@ function refresh_sceneitem(find_newest)
                 end
 
                 if not sceneitem then
-                    log("Warning: Source not part of the current scene hierarchy")
+                    log("WARNING: Source not part of the current scene hierarchy.\n" ..
+                        "         Try selecting a different zoom source or switching scenes.")
                     obs.obs_sceneitem_release(sceneitem)
                     obs.obs_source_release(source)
 
@@ -350,6 +356,22 @@ function refresh_sceneitem(find_newest)
                 end
 
                 monitor_info = get_monitor_info(source)
+            end
+        end
+    end
+
+    local is_non_display_capture = false
+    if source ~= nil then
+        -- Do a quick check to ensure this is a display capture
+        if allow_all_sources then
+            local source_type = obs.obs_source_get_id(source)
+            if source_type ~= "monitor_capture" then
+                is_non_display_capture = true
+
+                if not use_monitor_override then
+                    log("ERROR: Selected Zoom Source is not a display capture source.\n" ..
+                        "       You MUST enable 'Set manual source position' and set the correct override values for size and position.")
+                end
             end
         end
     end
@@ -368,14 +390,23 @@ function refresh_sceneitem(find_newest)
         sceneitem_crop = obs.obs_sceneitem_crop()
         obs.obs_sceneitem_get_crop(sceneitem, sceneitem_crop)
 
+        if is_non_display_capture then
+            -- Non-Display Capture sources don't correctly report crop values
+            sceneitem_crop_orig.left = 0
+            sceneitem_crop_orig.top = 0
+            sceneitem_crop_orig.right = 0
+            sceneitem_crop_orig.bottom = 0
+        end
+
         -- Get the current source size (this will be the value after any applied crop filters)
         if not source then
-            log("Error: Could not get source for sceneitem (" .. source_name .. ")")
+            log("ERROR: Could not get source for sceneitem (" .. source_name .. ")")
         end
 
         -- TODO: Figure out why we need this fallback code
-        local source_width = obs.obs_source_get_width(source)
-        local source_height = obs.obs_source_get_height(source)
+        local source_width = obs.obs_source_get_base_width(source)
+        local source_height = obs.obs_source_get_base_height(source)
+
         if source_width == 0 then
             source_width = source_raw.width
         end
@@ -383,17 +414,16 @@ function refresh_sceneitem(find_newest)
             source_height = source_raw.height
         end
 
-        log("Source size determined as " .. source_width .. ", " .. source_height)
         if source_width == 0 or source_height == 0 then
-            if monitor_info and monitor_info.height > 0 and monitor_info.height > 0 then
-                log("Warning: Something went wrong determining source size, defaulting to monitor size " ..
-                    monitor_info.width .. ", " .. monitor_info.height)
+            log("ERROR: Something went wrong determining source size." ..
+                "       Try using the 'Set manual source position' option and adding override values")
+
+            if monitor_info ~= nil then
                 source_width = monitor_info.width
                 source_height = monitor_info.height
-            else
-                log("Error: Something went wrong determining source size," ..
-                    "try using the 'Set manual monitor position' option and adding override values")
             end
+        else
+            log("Using source size: " .. source_width .. ", " .. source_height)
         end
 
         -- Convert the current transform into one we can correctly modify for zooming
@@ -406,9 +436,9 @@ function refresh_sceneitem(find_newest)
 
             obs.obs_sceneitem_set_info(sceneitem, sceneitem_info)
 
-            log("Warning: Found existing non-boundingbox transform. This may cause issues with zooming.\n" ..
-                "Settings have been auto converted to a bounding box scaling transfrom instead.\n" ..
-                "If you have issues with your layout consider making the transform use a bounding box manually.")
+            log("WARNING: Found existing non-boundingbox transform. This may cause issues with zooming.\n" ..
+                "         Settings have been auto converted to a bounding box scaling transfrom instead.\n" ..
+                "         If you have issues with your layout consider making the transform use a bounding box manually.")
         end
 
         -- Get information about any existing crop filters (that aren't ours)
@@ -420,7 +450,7 @@ function refresh_sceneitem(find_newest)
                 local id = obs.obs_source_get_id(v)
                 if id == "crop_filter" then
                     local name = obs.obs_source_get_name(v)
-                    if name ~= CROP_FILTER_NAME then
+                    if name ~= CROP_FILTER_NAME and name ~= "temp_" .. CROP_FILTER_NAME then
                         found_crop_filter = true
                         local settings = obs.obs_source_get_settings(v)
                         if settings ~= nil then
@@ -437,9 +467,8 @@ function refresh_sceneitem(find_newest)
                                     name ..
                                     "). Applying settings " .. format_table(zoom_info.source_crop_filter))
                             else
-                                log("Warning: Found existing non-relative crop/pad filter (" ..
-                                    name ..
-                                    ").\nThis will cause issues with zooming.\nConvert to relative settings instead.")
+                                log("WARNING: Found existing non-relative crop/pad filter (" .. name .. ").\n" ..
+                                    "         This will cause issues with zooming. Convert to relative settings instead.")
                             end
                             obs.obs_data_release(settings)
                         end
@@ -481,9 +510,12 @@ function refresh_sceneitem(find_newest)
             sceneitem_crop.bottom = 0
             obs.obs_sceneitem_set_crop(sceneitem, sceneitem_crop)
 
-            log("Warning: Found existing transform crop. This may cause issues with zooming.\n" ..
-                "Settings have been auto converted to a relative crop/pad filter instead.\n" ..
-                "If you have issues with your layout consider making the filter manually.")
+            log("WARNING: Found existing transform crop. This may cause issues with zooming.\n" ..
+                "         Settings have been auto converted to a relative crop/pad filter instead.\n" ..
+                "         If you have issues with your layout consider making the filter manually.")
+        elseif found_crop_filter then
+            source_width = zoom_info.source_crop_filter.w
+            source_height = zoom_info.source_crop_filter.h
         end
 
         -- Get the rest of the information needed to correctly zoom
@@ -523,9 +555,9 @@ end
 
 ---
 -- Get the target position that we will attempt to zoom towards
----@param zoom_info any
+---@param zoom any
 ---@return table
-function get_target_position(zoom_info)
+function get_target_position(zoom)
     local mouse = get_mouse_pos()
 
     -- If we have monitor information then we can offset the mouse by the top-left of the monitor position
@@ -537,15 +569,24 @@ function get_target_position(zoom_info)
     end
 
     -- Now offset the mouse by the crop top-left because if we cropped 100px off of the display clicking at 100,0 should really be the top-left 0,0
-    mouse.x = mouse.x - zoom_info.source_crop_filter.x
-    mouse.y = mouse.y - zoom_info.source_crop_filter.y
+    mouse.x = mouse.x - zoom.source_crop_filter.x
+    mouse.y = mouse.y - zoom.source_crop_filter.y
+
+    -- If the source uses a different scale to the display, apply that now.
+    -- This can happen with cloned sources, where it is cloning a scene that has a full screen display.
+    -- The display will be the full desktop pixel size, but the cloned scene will be scaled down to the canvas,
+    -- so we need to scale down the mouse movement to match
+    if monitor_info and monitor_info.scale_x and monitor_info.scale_y then
+        mouse.x = mouse.x * monitor_info.scale_x
+        mouse.y = mouse.y * monitor_info.scale_y
+    end
 
     -- Get the new size after we zoom
     -- Remember that because we are using a crop/pad filter making the size smaller (dividing by zoom) means that we see less of the image
     -- in the same amount of space making it look bigger (aka zoomed in)
     local new_size = {
-        width = zoom_info.source_size.width / zoom_info.zoom_to,
-        height = zoom_info.source_size.height / zoom_info.zoom_to
+        width = zoom.source_size.width / zoom.zoom_to,
+        height = zoom.source_size.height / zoom.zoom_to
     }
 
     -- New offset for the crop/pad filter is whereever we clicked minus half the size, so that the clicked point because the new center
@@ -563,8 +604,8 @@ function get_target_position(zoom_info)
     }
 
     -- Keep the zoom in bounds of the source so that we never show something outside that user is trying to hide with existing crop settings
-    crop.x = math.floor(clamp(0, (zoom_info.source_size.width - new_size.width), crop.x))
-    crop.y = math.floor(clamp(0, (zoom_info.source_size.height - new_size.height), crop.y))
+    crop.x = math.floor(clamp(0, (zoom.source_size.width - new_size.width), crop.x))
+    crop.y = math.floor(clamp(0, (zoom.source_size.height - new_size.height), crop.y))
 
     return { crop = crop, raw_center = mouse, clamped_center = { x = math.floor(crop.x + crop.w * 0.5), y = math.floor(crop.y + crop.h * 0.5) } }
 end
@@ -783,7 +824,7 @@ end
 
 function on_update_transform()
     -- Update the crop/size settings based on whatever the source in the current scene looks like
-    refresh_sceneitem(false)
+    refresh_sceneitem(true)
     return true
 end
 
@@ -797,10 +838,29 @@ function on_settings_modified(props, prop, settings)
         obs.obs_property_set_visible(obs.obs_properties_get(props, "monitor_override_y"), visible)
         obs.obs_property_set_visible(obs.obs_properties_get(props, "monitor_override_w"), visible)
         obs.obs_property_set_visible(obs.obs_properties_get(props, "monitor_override_h"), visible)
+        obs.obs_property_set_visible(obs.obs_properties_get(props, "monitor_override_sx"), visible)
+        obs.obs_property_set_visible(obs.obs_properties_get(props, "monitor_override_sy"), visible)
     elseif name == "debug_logs" then
         if obs.obs_data_get_bool(settings, "debug_logs") then
             log_current_settings()
         end
+    elseif name == "allow_all_sources" then
+        local sources_list = obs.obs_properties_get(props, "source")
+        populate_zoom_sources(sources_list)
+    end
+
+    if name == "use_monitor_override" or
+        name == "monitor_override_x" or
+        name == "monitor_override_y" or
+        name == "monitor_override_w" or
+        name == "monitor_override_h" or
+        name == "monitor_override_sx" or
+        name == "monitor_override_sy" then
+        local visible = obs.obs_data_get_bool(settings, "use_monitor_override")
+        if visible and source ~= nil then
+            monitor_info = get_monitor_info(source)
+        end
+        return name == "use_monitor_override"
     end
 
     return true
@@ -846,11 +906,14 @@ function on_print_help()
         "Follow Border: The %distance from the edge of the source that will re-enable mouse tracking\n" ..
         "Lock Sensitivity: How close the tracking needs to get before it locks into position and stops tracking until you enter the follow border\n" ..
         "Auto Lock on reverse direction: Automatically stop tracking if you reverse the direction of the mouse\n" ..
-        "Set manual monitor position: True to override the calculated x,y topleft position for the selected display\n" ..
+        "Show all sources: True to allow selecting any source as the Zoom Source - You MUST set manual source position for non-display capture sources\n" ..
+        "Set manual source position: True to override the calculated x/y (topleft position), width/height (size), and scaleX/scaleY (canvas scale factor) for the selected source\n" ..
         "X: The coordinate of the left most pixel of the display\n" ..
         "Y: The coordinate of the top most pixel of the display\n" ..
         "Width: The width of the display in pixels\n" ..
         "Height: The height of the display in pixels\n" ..
+        "Scale X: The x scale factor to apply to the mouse position if the source size is not 1:1 (useful for cloned sources)\n" ..
+        "Scale Y: The y scale factor to apply to the mouse position if the source size is not 1:1 (useful for cloned sources)\n" ..
         "More Info: Show this text in the script log\n" ..
         "Enable debug logging: Show additional debug information in the script log\n\n"
 
@@ -867,25 +930,23 @@ function script_properties()
     -- Populate the sources list with the known display-capture sources (OBS calls them 'monitor_capture' internally even though the UI says 'Display Capture')
     local sources_list = obs.obs_properties_add_list(props, "source", "Zoom Source", obs.OBS_COMBO_TYPE_LIST,
         obs.OBS_COMBO_FORMAT_STRING)
-    local sources = obs.obs_enum_sources()
-    if sources ~= nil then
-        for _, source in ipairs(sources) do
-            local source_id = obs.obs_source_get_id(source)
-            local source_type = obs.obs_source_get_id(source)
-            if source_type == "monitor_capture" then
-                local name = obs.obs_source_get_name(source)
-                obs.obs_property_list_add_string(sources_list, name, name)
-            end
-        end
-        obs.source_list_release(sources)
-    end
+
+    populate_zoom_sources(sources_list)
+
+    obs.obs_properties_add_button(props, "refresh", "Refresh zoom sources",
+        function()
+            populate_zoom_sources(sources_list)
+            return true
+        end)
 
     -- This button is used to recalculate the sceneitem and all the transform/crop values
     -- The idea being that if the user moves around the display capture source in their scene layout,
     -- they have a way to reset the zoom settings for the new info
     -- We could potentially do this automatically by listening to a bunch of events to see if anything changes
     -- but this is easier
-    obs.obs_properties_add_button(props, "update_transform", "Force transform update", on_update_transform)
+    local force = obs.obs_properties_add_button(props, "update_transform", "Force transform update", on_update_transform)
+    obs.obs_property_set_long_description(force,
+        "Click to refresh the internal zoom data if you manually change the transform/filters on your zoom source")
 
     -- Add the rest of the settings UI
     local zoom = obs.obs_properties_add_float(props, "zoom_value", "Zoom Factor", 1, 5, 0.5)
@@ -898,11 +959,20 @@ function script_properties()
         "follow_safezone_sensitivity", "Lock Sensitivity", 1, 20, 1)
     local follow_auto_lock = obs.obs_properties_add_bool(props, "follow_auto_lock", "Auto Lock on reverse direction")
 
-    local override = obs.obs_properties_add_bool(props, "use_monitor_override", "Set manual monitor position")
+    local allow_all = obs.obs_properties_add_bool(props, "allow_all_sources", "Allow any zoom source ")
+    obs.obs_property_set_long_description(allow_all, "Enable to allow selecting any source as the Zoom Source\n" ..
+        "You MUST set manual source position for non-display capture sources")
+
+    local override = obs.obs_properties_add_bool(props, "use_monitor_override", "Set manual source position")
     local override_x = obs.obs_properties_add_int(props, "monitor_override_x", "X", 0, 10000, 1)
     local override_y = obs.obs_properties_add_int(props, "monitor_override_y", "Y", 0, 10000, 1)
-    local override_w = obs.obs_properties_add_int(props, "monitor_override_w", "X", 0, 10000, 1)
-    local override_h = obs.obs_properties_add_int(props, "monitor_override_h", "Y", 0, 10000, 1)
+    local override_w = obs.obs_properties_add_int(props, "monitor_override_w", "Width", 0, 10000, 1)
+    local override_h = obs.obs_properties_add_int(props, "monitor_override_h", "Height", 0, 10000, 1)
+    local override_sx = obs.obs_properties_add_float(props, "monitor_override_sx", "Scale X ", 0, 100, 0.01)
+    local override_sy = obs.obs_properties_add_float(props, "monitor_override_sy", "Scale Y ", 0, 100, 0.01)
+
+    obs.obs_property_set_long_description(override_sx, "Usually 1 - unless you are using a scaled source")
+    obs.obs_property_set_long_description(override_sy, "Usually 1 - unless you are using a scaled source")
 
     -- Add a button for more information
     obs.obs_properties_add_button(props, "help_button", "More Info", on_print_help)
@@ -912,7 +982,16 @@ function script_properties()
     obs.obs_property_set_visible(override_y, use_monitor_override)
     obs.obs_property_set_visible(override_w, use_monitor_override)
     obs.obs_property_set_visible(override_h, use_monitor_override)
+    obs.obs_property_set_visible(override_sx, use_monitor_override)
+    obs.obs_property_set_visible(override_sy, use_monitor_override)
+    obs.obs_property_set_modified_callback(override_x, on_settings_modified)
+    obs.obs_property_set_modified_callback(override_y, on_settings_modified)
+    obs.obs_property_set_modified_callback(override_w, on_settings_modified)
+    obs.obs_property_set_modified_callback(override_h, on_settings_modified)
+    obs.obs_property_set_modified_callback(override_sx, on_settings_modified)
+    obs.obs_property_set_modified_callback(override_sy, on_settings_modified)
     obs.obs_property_set_modified_callback(override, on_settings_modified)
+    obs.obs_property_set_modified_callback(allow_all, on_settings_modified)
     obs.obs_property_set_modified_callback(debug, on_settings_modified)
 
     return props
@@ -946,11 +1025,14 @@ function script_load(settings)
     follow_border = obs.obs_data_get_int(settings, "follow_border")
     follow_safezone_sensitivity = obs.obs_data_get_int(settings, "follow_safezone_sensitivity")
     use_follow_auto_lock = obs.obs_data_get_bool(settings, "follow_auto_lock")
+    allow_all_sources = obs.obs_data_get_bool(settings, "allow_all_sources")
     use_monitor_override = obs.obs_data_get_bool(settings, "use_monitor_override")
     monitor_override_x = obs.obs_data_get_int(settings, "monitor_override_x")
     monitor_override_y = obs.obs_data_get_int(settings, "monitor_override_y")
     monitor_override_w = obs.obs_data_get_int(settings, "monitor_override_w")
     monitor_override_h = obs.obs_data_get_int(settings, "monitor_override_h")
+    monitor_override_sx = obs.obs_data_get_double(settings, "monitor_override_sx")
+    monitor_override_sy = obs.obs_data_get_double(settings, "monitor_override_sy")
     debug_logs = obs.obs_data_get_bool(settings, "debug_logs")
 
     obs.obs_frontend_add_event_callback(on_frontend_event)
@@ -978,11 +1060,14 @@ function script_defaults(settings)
     obs.obs_data_set_default_int(settings, "follow_border", 8)
     obs.obs_data_set_default_int(settings, "follow_safezone_sensitivity", 4)
     obs.obs_data_set_default_bool(settings, "follow_auto_lock", false)
+    obs.obs_data_set_default_bool(settings, "allow_all_sources", false)
     obs.obs_data_set_default_bool(settings, "use_monitor_override", false)
     obs.obs_data_set_default_int(settings, "monitor_override_x", 0)
     obs.obs_data_set_default_int(settings, "monitor_override_y", 0)
     obs.obs_data_set_default_int(settings, "monitor_override_w", 1920)
     obs.obs_data_set_default_int(settings, "monitor_override_h", 1080)
+    obs.obs_data_set_default_double(settings, "monitor_override_sx", 1)
+    obs.obs_data_set_default_double(settings, "monitor_override_sy", 1)
     obs.obs_data_set_default_bool(settings, "debug_logs", false)
 end
 
@@ -1014,15 +1099,35 @@ function script_update(settings)
     follow_border = obs.obs_data_get_int(settings, "follow_border")
     follow_safezone_sensitivity = obs.obs_data_get_int(settings, "follow_safezone_sensitivity")
     use_follow_auto_lock = obs.obs_data_get_bool(settings, "follow_auto_lock")
+    allow_all_sources = obs.obs_data_get_bool(settings, "allow_all_sources")
     use_monitor_override = obs.obs_data_get_bool(settings, "use_monitor_override")
     monitor_override_x = obs.obs_data_get_int(settings, "monitor_override_x")
     monitor_override_y = obs.obs_data_get_int(settings, "monitor_override_y")
     monitor_override_w = obs.obs_data_get_int(settings, "monitor_override_w")
     monitor_override_h = obs.obs_data_get_int(settings, "monitor_override_h")
+    monitor_override_sx = obs.obs_data_get_double(settings, "monitor_override_sx")
+    monitor_override_sy = obs.obs_data_get_double(settings, "monitor_override_sy")
     debug_logs = obs.obs_data_get_bool(settings, "debug_logs")
 
     -- Only do the expensive refresh if the user selected a new source
     if source_name ~= old_source_name then
         refresh_sceneitem(true)
+    end
+end
+
+function populate_zoom_sources(list)
+    obs.obs_property_list_clear(list)
+
+    local sources = obs.obs_enum_sources()
+    if sources ~= nil then
+        for _, source in ipairs(sources) do
+            local source_type = obs.obs_source_get_id(source)
+            if source_type == "monitor_capture" or allow_all_sources then
+                local name = obs.obs_source_get_name(source)
+                obs.obs_property_list_add_string(list, name, name)
+            end
+        end
+
+        obs.source_list_release(sources)
     end
 end

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    * **Lock Sensitivity**: How close the tracking needs to get before it locks into position and stops tracking until you enter the follow border
    * **Auto Lock on reverse direction**: Automatically stop tracking if you reverse the direction of the mouse.
    * **Show all sources**: True to allow selecting any source as the Zoom Source - Note: You **MUST** set manual source position for non-display capture sources
-   * **Set manual source position**: True to override the calculated x/y (topleft position), width/height (size), and scaleX/scaleY (canvas scale factor) for the selected source
+   * **Set manual source position**: True to override the calculated x/y (topleft position), width/height (size), and scaleX/scaleY (canvas scale factor) for the selected source. This is essentially the area of the desktop that the selected zoom source represents. Usually the script can calculate this, but if you are using a non-display capture source, or if the script gets it wrong, you can manually set the values.
    * **X**: The coordinate of the left most pixel of the display
    * **Y**: The coordinate of the top most pixel of the display
    * **Width**: The width of the display in pixels

--- a/readme.md
+++ b/readme.md
@@ -46,11 +46,14 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    * **Follow Border**: The %distance from the edge of the source that will re-enable mouse tracking
    * **Lock Sensitivity**: How close the tracking needs to get before it locks into position and stops tracking until you enter the follow border
    * **Auto Lock on reverse direction**: Automatically stop tracking if you reverse the direction of the mouse.
-   * **Set manual monitor position**: True to override the calculated x,y topleft position for the selected display
+   * **Show all sources**: True to allow selecting any source as the Zoom Source - Note: You **MUST** set manual source position for non-display capture sources
+   * **Set manual source position**: True to override the calculated x/y (topleft position), width/height (size), and scaleX/scaleY (canvas scale factor) for the selected source
    * **X**: The coordinate of the left most pixel of the display
    * **Y**: The coordinate of the top most pixel of the display
    * **Width**: The width of the display in pixels
    * **Height**: The height of the display in pixels
+   * **Scale X**: The x scale factor to apply to the mouse position if the source is not 1:1 pixel size (normally left as 1, but useful for cloned sources that have been scaled)
+   * **Scale Y**: The y scale factor to apply to the mouse position if the source is not 1:1 pixel size (normally left as 1, but useful for cloned sources that have been scaled)
    * **More Info**: Show this text in the script log
    * **Enable debug logging**: Show additional debug information in the script log
 
@@ -65,14 +68,46 @@ When you move your mouse to the edge of the zoom area, it will then start tracki
 
 How close you need to get to the edge of the zoom to trigger the 'start following mode' is determined by the `Follow Border` setting. This value is a pertentage of the area from the edge. If you set this to 0%, it means that you need to move the mouse to the very edge of the area to trigger mouse tracking. Something like 4% will give you a small border around the area. Setting it to full 50% causes it to begin following the mouse whenever it gets closer than 50% to an edge, which means it will follow the cursor *all the time* essentially removing the "safe zone".
 
-You can also modify this behavior with the `Auto Lock on reverse direction` setting, which attempts to make the follow work more like camera panning in a video game. When moving your mouse to the edge of the screen (how close determined by `Follow Border`) it will cause the camera to pan in that direction. Instead of continuing to track the mouse until you keep it still, with this setting it will also stop tracking immediately if you move your mouse back towards the center. 
+You can also modify this behavior with the `Auto Lock on reverse direction` setting, which attempts to make the follow work more like camera panning in a video game. When moving your mouse to the edge of the screen (how close determined by `Follow Border`) it will cause the camera to pan in that direction. Instead of continuing to track the mouse until you keep it still, with this setting it will also stop tracking immediately if you move your mouse back towards the center.
+
+### More information on 'Show All Sources'
+If you enable the `Show all sources` option, you will be able to select any OBS source as the `Zoom Source`. This includes **any** non-display capture items such as cloned sources, browsers, or windows (or even things like audio input - which really won't work!).
+
+Selecting a non-display capture zoom source means the script will **not be able to automatically calculate the position and size of the source**, so zooming and tracking the mouse position will be wrong!
+
+To fix this, you MUST manually enter the size and position of your selected zoom source by enabling the `Set manual source position` option and filling in the `X`, `Y`, `Width`, and `Height` values. These values are the pixel topleft position and pixel size of the source on your overall desktop. You may also need to set the `Scale X` and `Scale Y` values if you find that the mouse position is incorrectly offset when you zoom, which is due to the source being scaled differently than the monitor you are using.
+
+Example 1 - A 500x300 window positioned at the center of a single 1000x900 monitor, would need the following values:
+   * X = 250 (center of monitor X 500 - half width of window 250)
+   * Y = 300 (center of monitor Y 450 - half height of window 150)
+   * Width = 500 (window width)
+   * Height = 300 (window height)
+
+Example 2 - A cloned display-capture source which is using the second 1920x1080 monitor of a two monitor side by side setup:
+   * X = 1921 (the left-most pixel position of the second monitor because it is immediately next to the other 1920 monitor)
+   * Y = 0 (the top-most pixel position of the monitor)
+   * Width = 1920 (monitor width)
+   * Height = 1080 (monitor height)
+
+Example 3 - A cloned scene source which is showing a 1920x1080 monitor but the scene canvas size is scaled down to 1024x768 setup:
+   * X = 0 (the left-most pixel position of the monitor)
+   * Y = 0 (the top-most pixel position of the monitor)
+   * Width = 1920 (monitor width)
+   * Height = 1080 (monitor height)
+   * Scale X = 0.53 (canvas width 1024 / monitor width 1920)
+   * Scale Y = 0.71 (canvas height 768 / monitor height 1080)
+
+I don't know of an easy way of getting these values automatically otherwise I would just have the script do it for you.
+
+Note: If you are also using a `transform crop` on the non-display capture source, you will need to manually convert it to a `Crop/Pad Filter` instead (the script has trouble trying to auto convert it for you for non-display sources).
 
 ## Known Limitations
 * Currently this script only works on **Windows**
    * Internally it uses [FFI](https://luajit.org/ext_ffi.html) to get the mouse position by loading the Win32 `GetCursorPos()` function
 
-* Only works on `Display Capture` sources
+* Only works on `Display Capture` sources (automatically)
    * In theory it should be able to work on window captures too, if there was a way to get the mouse position relative to that specific window
+   * You can now enable the [`Show all sources`](#More-information-on-'Show-All-Sources') option to select a non-display capture source, but you MUST set manual source position values
 
 ## Development Setup
 * Clone this repo


### PR DESCRIPTION
This PR adds a new feature to allow users to select non-display capture sources.

A new `Show all sources` checkbox has been added to the settings. When enabled, this will update the `Zoom Source` dropdown with all sources (instead of only display-capture sources). The user is able to select one of these sources and the script will attempt to zoom it like it would with a regular display source.

It is important to note that the script is unable to auto calculate the size and position of non-display capture sources, so the user will (almost always) need to also enable the `Set manual source position` option and set the values for the area of the desktop that the source is displaying.

Another caveat is that the auto conversion of `transform crop` to `Crop/Pad Filter` usually doesn't work correctly, because OBS reports the wrong crop values for non-display capture sources (or I'm doing it wrong).

* Added new `Show all sources` feature
* Update readme with more information
* Refactored errors/warnings to give more actionable messages to users