### PR TITLE
Allow negative source positions

### DIFF
--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -182,13 +182,13 @@ function get_monitor_info(source)
                 end
             end
 
-            -- This works for my machine as the monitor names are given as "U2790B: 3840x2160 @ 0,0 (Primary Monitor)"
+            -- This works for my machine as the monitor names are given as "U2790B: 3840x2160 @ -1920,0 (Primary Monitor)"
             -- I don't know if this holds true for other machines and/or OBS versions
             -- TODO: Update this with some custom FFI calls to find the monitor top-left x and y coordinates if it doesn't work for anyone else
             -- TODO: Refactor this into something that would work with Windows/Linux/Mac assuming we can't do it like this
             if found then
                 log("Parsing display name: " .. found)
-                local x, y = found:match("(%d+),(%d+)")
+                local x, y = found:match("(-?%d+),(-?%d+)")
                 local width, height = found:match("(%d+)x(%d+)")
 
                 info = { x = 0, y = 0, width = 0, height = 0 }
@@ -856,8 +856,7 @@ function on_settings_modified(props, prop, settings)
         name == "monitor_override_h" or
         name == "monitor_override_sx" or
         name == "monitor_override_sy" then
-        local visible = obs.obs_data_get_bool(settings, "use_monitor_override")
-        if visible and source ~= nil then
+        if source ~= nil then
             monitor_info = get_monitor_info(source)
         end
         return name == "use_monitor_override"
@@ -964,8 +963,8 @@ function script_properties()
         "You MUST set manual source position for non-display capture sources")
 
     local override = obs.obs_properties_add_bool(props, "use_monitor_override", "Set manual source position")
-    local override_x = obs.obs_properties_add_int(props, "monitor_override_x", "X", 0, 10000, 1)
-    local override_y = obs.obs_properties_add_int(props, "monitor_override_y", "Y", 0, 10000, 1)
+    local override_x = obs.obs_properties_add_int(props, "monitor_override_x", "X", -10000, 10000, 1)
+    local override_y = obs.obs_properties_add_int(props, "monitor_override_y", "Y", -10000, 10000, 1)
     local override_w = obs.obs_properties_add_int(props, "monitor_override_w", "Width", 0, 10000, 1)
     local override_h = obs.obs_properties_add_int(props, "monitor_override_h", "Height", 0, 10000, 1)
     local override_sx = obs.obs_properties_add_float(props, "monitor_override_sx", "Scale X ", 0, 100, 0.01)

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    **Note:** If you don't use this form of setup for your display source (E.g. you have bounding box set to `No bounds` or you have a `Crop` set on the transform), the script will attempt to **automatically change your settings** to zoom compatible ones. 
    This may have undesired effects on your layout (or just not work at all).
 
+   **Note:** If you change your desktop display properties in Windows (such as moving a monitor, changing your primary display, updating the orientation of a display), you will need to re-add your display capture source in OBS for it to update the values that the script uses for its auto calculations.
+
 ## Usage
 1. You can customize the following settings in the OBS Scripts window:
    * **Zoom Source**: The display capture in the current scene to use for zooming

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    **Note:** If you don't use this form of setup for your display source (E.g. you have bounding box set to `No bounds` or you have a `Crop` set on the transform), the script will attempt to **automatically change your settings** to zoom compatible ones. 
    This may have undesired effects on your layout (or just not work at all).
 
-   **Note:** If you change your desktop display properties in Windows (such as moving a monitor, changing your primary display, updating the orientation of a display), you will need to re-add your display capture source in OBS for it to update the values that the script uses for its auto calculations.
+   **Note:** If you change your desktop display properties in Windows (such as moving a monitor, changing your primary display, updating the orientation of a display), you will need to re-add your display capture source in OBS for it to update the values that the script uses for its auto calculations. You will then need to reload the script.
 
 ## Usage
 1. You can customize the following settings in the OBS Scripts window:


### PR DESCRIPTION
This PR fixes an issue with multiple displays when there is a monitor to the left/above of the primary display.

**Issue:**
When a monitor is to the left of the primary display, the zoom feature does not correctly track the mouse and will instead zoom into a side of the source.

**Cause:**
This is caused by the script not correctly parsing negative X/Y coordinates. Windows will assign the primary display as position 0,0. Monitors to the left of that will get a negative X position (and monitors above will get a negative Y). The script was ignoring the minus symbol so the tracking was all messed up.

**Fix:**
The fix is to update the regex to account for negative values so that the offset is correctly set. We should also allow users to set a negative position in the `Set manual source position` settings.

* Updated regex in `get_monitor_info` to account for `-`
* Allow negative X/Y positions in settings
* Updated readme