### PR TITLE
Add transition event to prevent blink

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,6 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
 ## Usage
 1. You can customize the following settings in the OBS Scripts window:
    * **Zoom Source**: The display capture in the current scene to use for zooming
-   * **Force transform update**: Click to refresh the internal zoom data if you manually change the transform/filters on your zoom source
    * **Zoom Factor**: How much to zoom in by
    * **Zoom Speed**: The speed of the zoom in/out animation
    * **Auto follow mouse**: True to track the cursor automatically while you are zoomed in, instead of waiting for the `Toggle follow` hotkey to be pressed first


### PR DESCRIPTION
This PR fixes an issue with changing scenes when the transform applied to the source in each scene is different.

**Issue:**
When changing scenes we release the sceneitem and revert the transform back to the original to prevent a bad state with the source layout. In the new scene we find the new sceneitem (assuming it exists) and apply the zooming filter settings. This would cause a noticeable blink if the source had a different transform set as you would see it in the old state before we applied the new settings

**Fix:**
The fix is to listen to the `transition_start` event so that we can release the sceneitem before the new scene has loaded. This prevents seeing the wrong filter settings applied, so the 'blink' goes away.

Also added a new `None` option for the zoom source, selecting this will revert the transform back to the original and remove the zoom filter settings. This allows users to modify the transform and re-apply the zoom calculations much easier than what the `Force Transform Update` button was trying to do. So that button has now been removed.

* Add OBS version to logs
* Listen for `transition_start` event
* Release sceneitem during transition
* Add checks for display source before doing the expensive filter changes
* Replace `force transform update` button with none selection