### PR TITLE
Add provisional Mac and Linux support

### DIFF
--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -129,22 +129,7 @@ elseif ffi.os == "OSX" then
         int access(const char *path, int amode);
     ]])
 
-    local framework = "AppKit"
-    local frameworkSearchPaths = {
-        "/System/Library/Frameworks/%s.framework/%s",
-        "/Library/Frameworks/%s.framework/%s",
-        "~/Library/Frameworks/%s.framework/%s"
-    }
-
-    -- Find the OSX lib to load
-    for i, path in pairs(frameworkSearchPaths) do
-        path = path:format(framework, framework)
-        if ffi.C.access(path, 4) == 0 then
-            osx_lib = ffi.load(path, true)
-            break
-        end
-    end
-
+    osx_lib = ffi.load("libobjc")
     if osx_lib ~= nil then
         osx_nsevent = {
             class = osx_lib.objc_getClass("NSEvent"),
@@ -212,7 +197,7 @@ function get_dc_info()
     elseif ffi.os == "OSX" then
         if major > 29.1 then
             return {
-                source_id = "display_capture",
+                source_id = "screen_capture",
                 prop_id = "display_uuid",
                 prop_type = "string"
             }
@@ -549,8 +534,6 @@ function refresh_sceneitem(find_newest)
                     source = nil
                     return
                 end
-
-                monitor_info = get_monitor_info(source)
             end
         end
     end

--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -6,7 +6,7 @@
 
 local obs = obslua
 local ffi = require("ffi")
-local VERSION = "1.0"
+local VERSION = "1.0.1"
 local CROP_FILTER_NAME = "obs-zoom-to-mouse-crop"
 
 local source_name = ""
@@ -1065,6 +1065,7 @@ function log_current_settings()
     }
 
     log("OBS Version: " .. string.format("%.1f", major))
+    log("Script Version: " .. VERSION)
     log("Current settings:")
     log(format_table(settings))
 end

--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -6,7 +6,7 @@
 
 local obs = obslua
 local ffi = require("ffi")
-local VERSION = "1.0.1"
+local VERSION = "1.0"
 local CROP_FILTER_NAME = "obs-zoom-to-mouse-crop"
 
 local source_name = ""
@@ -195,7 +195,7 @@ function get_dc_info()
             prop_type = "int"
         }
     elseif ffi.os == "OSX" then
-        if major > 29.1 then
+        if major > 29.0 then
             return {
                 source_id = "screen_capture",
                 prop_id = "display_uuid",
@@ -1065,7 +1065,6 @@ function log_current_settings()
     }
 
     log("OBS Version: " .. string.format("%.1f", major))
-    log("Script Version: " .. VERSION)
     log("Current settings:")
     log(format_table(settings))
 end
@@ -1255,7 +1254,7 @@ end
 
 function script_unload()
     -- Clean up the memory usage
-    if major > 29.0 then
+    if major > 29.0 then -- 29.0 seems to crash if you do this, so we ignore it as the script is closing anyway
         local transitions = obs.obs_frontend_get_transitions()
         if transitions ~= nil then
             for i, s in pairs(transitions) do

--- a/readme.md
+++ b/readme.md
@@ -49,12 +49,14 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    * **Auto Lock on reverse direction**: Automatically stop tracking if you reverse the direction of the mouse.
    * **Show all sources**: True to allow selecting any source as the Zoom Source - Note: You **MUST** set manual source position for non-display capture sources
    * **Set manual source position**: True to override the calculated x/y (topleft position), width/height (size), and scaleX/scaleY (canvas scale factor) for the selected source. This is essentially the area of the desktop that the selected zoom source represents. Usually the script can calculate this, but if you are using a non-display capture source, or if the script gets it wrong, you can manually set the values.
-   * **X**: The coordinate of the left most pixel of the display
-   * **Y**: The coordinate of the top most pixel of the display
-   * **Width**: The width of the display in pixels
-   * **Height**: The height of the display in pixels
+   * **X**: The coordinate of the left most pixel of the source
+   * **Y**: The coordinate of the top most pixel of the source
+   * **Width**: The width of the source (in pixels)
+   * **Height**: The height of the source (in pixels)
    * **Scale X**: The x scale factor to apply to the mouse position if the source is not 1:1 pixel size (normally left as 1, but useful for cloned sources that have been scaled)
    * **Scale Y**: The y scale factor to apply to the mouse position if the source is not 1:1 pixel size (normally left as 1, but useful for cloned sources that have been scaled)
+   * **Monitor Width**: The width of the monitor that is showing the source (in pixels)
+   * **Monitor Height**: The height of the monitor that is showing the source (in pixels)
    * **More Info**: Show this text in the script log
    * **Enable debug logging**: Show additional debug information in the script log
 
@@ -103,8 +105,9 @@ I don't know of an easy way of getting these values automatically otherwise I wo
 Note: If you are also using a `transform crop` on the non-display capture source, you will need to manually convert it to a `Crop/Pad Filter` instead (the script has trouble trying to auto convert it for you for non-display sources).
 
 ## Known Limitations
-* Currently this script only works on **Windows**
+* Currently this script is only tested on **Windows**
    * Internally it uses [FFI](https://luajit.org/ext_ffi.html) to get the mouse position by loading the Win32 `GetCursorPos()` function
+   * You can now try out support for **Linux** and **Mac** using the latest version of the script (they have their own [FFI](https://luajit.org/ext_ffi.html) defines for getting the mouse position)
 
 * Only works on `Display Capture` sources (automatically)
    * In theory it should be able to work on window captures too, if there was a way to get the mouse position relative to that specific window

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ I made this for my own use when recording videos as I wanted a way to zoom into 
 
 Built with OBS v29.1.3
 
+Now works on **Windows**, **Linux**, and **Mac**
+
 Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](https://github.com/tryptech/obs-zoom-and-follow)
 
 ## Example
@@ -105,13 +107,16 @@ I don't know of an easy way of getting these values automatically otherwise I wo
 Note: If you are also using a `transform crop` on the non-display capture source, you will need to manually convert it to a `Crop/Pad Filter` instead (the script has trouble trying to auto convert it for you for non-display sources).
 
 ## Known Limitations
-* Currently this script is only tested on **Windows**
-   * Internally it uses [FFI](https://luajit.org/ext_ffi.html) to get the mouse position by loading the Win32 `GetCursorPos()` function
-   * You can now try out support for **Linux** and **Mac** using the latest version of the script (they have their own [FFI](https://luajit.org/ext_ffi.html) defines for getting the mouse position)
-
 * Only works on `Display Capture` sources (automatically)
    * In theory it should be able to work on window captures too, if there was a way to get the mouse position relative to that specific window
    * You can now enable the [`Show all sources`](#More-information-on-'Show-All-Sources') option to select a non-display capture source, but you MUST set manual source position values
+
+* Using Linux:
+   * You may need to install the [loopback package](https://obsproject.com/forum/threads/obs-no-display-screen-capture-option.156314/) to enable `XSHM` display capture sources. This source acts most like the ones used by Windows and Mac so the script can auto calculate sizes for you.
+   * The script will also work with `Pipewire` sources, but you will need to enable `Allow any zoom source` and `Set manual source position` since the script cannot get the size by itself.
+
+* Using Mac:
+   * When using `Set manual source position` you may need to set the `Monitor Height` value as it is used to invert the Y coordinate of the mouse position so that it matches the values of Windows and Linux that the script expects.
 
 ## Development Setup
 * Clone this repo


### PR DESCRIPTION
This PR adds the FFI defines for Linux and Mac so that the script can now get the mouse position on those platforms.

*Inspired  by work shown in PR #14 by [v0l](https://github.com/v0l)*

**Note:** I only tested this on Ubuntu 22.04.2 and Mac OS Catalina (I know that's really old but it's the only apple device I have access to). This means it's possible (likely?) that the support won't work on other flavors of Linux or newer versions of Mac.

If anyone is interested in testing it out on other versions and modifying the code, you'll want to look at the `FFI` defines for each platform near the top of the file and the `get_mouse_pos()` function. For OSX specifically the `get_dc_info()` may need updating because the display-capture source for Mac changed between OBS 29.0 and 29.1 and catalina can only install 29.0 :(
 
* Added FFI code for OSX and Linux
* Added default display-capture source names for each platform
* Added ability to override the monitor width/height (mostly only needed for mac which inverts the mouse position Y value)