### PR TITLE
Add basic dual machine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Prevent uploading ljsocket.lua into this repo by accident
+ljsocket.lua

--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -6,7 +6,7 @@
 
 local obs = obslua
 local ffi = require("ffi")
-local VERSION = "1.0"
+local VERSION = "1.0.2"
 local CROP_FILTER_NAME = "obs-zoom-to-mouse-crop"
 
 local socket_available, socket = pcall(require, "ljsocket")
@@ -1158,7 +1158,8 @@ function log_current_settings()
         use_socket = use_socket,
         socket_port = socket_port,
         socket_poll = socket_poll,
-        debug_logs = debug_logs
+        debug_logs = debug_logs,
+        version = VERSION
     }
 
     log("OBS Version: " .. string.format("%.1f", major) .. "." .. minor)
@@ -1195,7 +1196,7 @@ function on_print_help()
 
     if socket_available then
         help = help ..
-            "Enable remote mouse listener: True to start a UDP socket server that will listen for mouse position messages from a remote client\n" ..
+            "Enable remote mouse listener: True to start a UDP socket server that will listen for mouse position messages from a remote client, see: https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote\n" ..
             "Port: The port number to use for the socket server\n" ..
             "Poll Delay: The time between updating the mouse position (in milliseconds)\n"
     end
@@ -1322,6 +1323,11 @@ end
 
 function script_load(settings)
     sceneitem_info_orig = nil
+
+    -- Workaround for detecting if OBS is already loaded and we were reloaded using "Reload Scripts"
+    local current_scene = obs.obs_frontend_get_current_scene()
+    is_obs_loaded = current_scene ~= nil -- Current scene is nil on first OBS load
+    obs.obs_source_release(current_scene)
 
     -- Add our hotkey
     hotkey_zoom_id = obs.obs_hotkey_register_frontend("toggle_zoom_hotkey", "Toggle zoom to mouse",

--- a/readme.md
+++ b/readme.md
@@ -62,15 +62,17 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    * **More Info**: Show this text in the script log
    * **Enable debug logging**: Show additional debug information in the script log
 
-1. If you have [ljsocket.lua](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) in the same directory as `obs-zoom-to-mouse.lua`, the following settings will also be available:
+1. In OBS, open File -> Settings -> Hotkeys 
+   * Add a hotkey for `Toggle zoom to mouse` to zoom in and out
+   * Add a hotkey for `Toggle follow mouse during zoom` to turn mouse tracking on and off (*Optional*)
+
+### Dual Machine Support
+1. The script also has some **basic** dual machine setup support. By using my related project [obs-zoom-to-mouse-remote](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) you will be able to track the mouse on your second machine
+1. When you have [ljsocket.lua](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) in the same directory as `obs-zoom-to-mouse.lua`, the following settings will also be available:
    * **Enable remote mouse listener**: True to start a UDP socket server that will listen for mouse position messages from a remote client
    * **Port**: The port number to use for the socket server
    * **Poll Delay**: The time between updating the mouse position (in milliseconds)
    * For more information see [obs-zoom-to-mouse-remote](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote)
-
-1. In OBS, open File -> Settings -> Hotkeys 
-   * Add a hotkey for `Toggle zoom to mouse` to zoom in and out
-   * Add a hotkey for `Toggle follow mouse during zoom` to turn mouse tracking on and off (*Optional*)
 
 ### More information on how mouse tracking works
 When you press the `Toggle zoom` hotkey the script will use the current mouse position as the center of the zoom. The script will then animate the width/height values of a crop/pan filter so it appears to zoom into that location. If you have `Auto follow mouse` turned on, then the x/y values of the filter will also change to keep the mouse in view as it is animating the zoom. Once the animation is complete, the script gives you a "safe zone" to move your cursor in without it moving the "camera". The idea was that you'd want to zoom in somewhere and move your mouse around to highlight code or whatever, without the screen moving so it would be easier to read text in the video.

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,12 @@ Inspired by [tryptech](https://github.com/tryptech)'s [obs-zoom-and-follow](http
    * **More Info**: Show this text in the script log
    * **Enable debug logging**: Show additional debug information in the script log
 
+1. If you have [ljsocket.lua](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) in the same directory as `obs-zoom-to-mouse.lua`, the following settings will also be available:
+   * **Enable remote mouse listener**: True to start a UDP socket server that will listen for mouse position messages from a remote client
+   * **Port**: The port number to use for the socket server
+   * **Poll Delay**: The time between updating the mouse position (in milliseconds)
+   * For more information see [obs-zoom-to-mouse-remote](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote)
+
 1. In OBS, open File -> Settings -> Hotkeys 
    * Add a hotkey for `Toggle zoom to mouse` to zoom in and out
    * Add a hotkey for `Toggle follow mouse during zoom` to turn mouse tracking on and off (*Optional*)


### PR DESCRIPTION
This PR adds some basic support for running OBS on one machine, while capturing the screen and mouse position from another machine (via capture card for example).

Essentially it adds a small UDP socket server that you can enable. When enabled the server will listen for mouse update information and use that when it calculates the zoom and tracking position.

To enable the new socket listener options you need to have ljsocket.lua in the same directory as the main lua script (though it does not need to be added to OBS as a script). You then need some external program to pass the mouse position to the socket server. For this, I have created a separate repository [obs-zoom-to-mouse-remote](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) which has a small socket client that will post mouse coordinates to the server. Check out that repo for more information.

* Updated version to 1.0.2
* Added check for ljsocket.lua and to show new options if found
* Added socket server to listen for mouse coordinates
* Updated `get_mouse_pos()` to use socket coordinates if available
* See: [obs-zoom-to-mouse-remote](https://github.com/BlankSourceCode/obs-zoom-to-mouse-remote) for more information
