### PR TITLE
Zoom Fixed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ An OBS lua script to zoom a display-capture source to focus on the mouse.
 I made this for my own use when recording videos as I wanted a way to zoom into my IDE when highlighting certain sections of code. My particular setup didn't seem to work very well with the existing zooming solutions so I created this.
 
 Built with OBS v29.1.3
+Now compatible with OBS Studio up to v32.0+
 
 Now works on **Windows**, **Linux**, and **Mac**
 


### PR DESCRIPTION
Changes Implemented
1. Added Compatibility Layer (lines 92-108)
Created two wrapper functions that automatically detect which OBS API functions are available:

sceneitem_get_info_compat() - uses either the old or new function based on availability
sceneitem_set_info_compat() - uses either the old or new function based on availability
2. Replaced All Deprecated Function Calls
Updated 4 instances of deprecated function calls:

Line 471: obs.obs_sceneitem_get_info() → sceneitem_get_info_compat()
Line 597: obs.obs_sceneitem_get_info() → sceneitem_get_info_compat()
Line 603: obs.obs_sceneitem_get_info() → sceneitem_get_info_compat()
Line 654: obs.obs_sceneitem_set_info() → sceneitem_set_info_compat()
3. Updated Version Information
Updated script version from 1.0.2 to 1.0.3
Added compatibility note: "Compatible with OBS Studio 29.1.3 through 32.0+"
Updated readme.md to reflect compatibility with OBS Studio up to v32.0+
Benefits of This Solution
Forward Compatible: Works with OBS 32.0 and future versions
Backward Compatible: Still works with older OBS versions (29.1.3+)
Automatic Detection: No user configuration needed - script automatically detects the available API
No Functionality Changes: All zoom and mouse tracking features work exactly as before
The script should now load and run correctly in OBS Studio 32.0 without any errors. Users can continue using all the zoom-to-mouse functionality as before.