### PR TITLE
performance updates for obs-zoom-to-mouse.lua?

### DIFF
--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -827,7 +827,7 @@ function refresh_sceneitem_deferred(find_newest, delay_ms)
     delay_ms = delay_ms or 150
     deferred_find_newest = find_newest
     if deferred_refresh_pending then
-        return
+        obs.timer_remove(deferred_refresh_callback)  -- Remove old timer
     end
     deferred_refresh_pending = true
     obs.timer_add(deferred_refresh_callback, delay_ms)
@@ -1339,10 +1339,7 @@ function populate_zoom_sources(list)
         obs.obs_property_list_add_string(list, "<None>", "obs-zoom-to-mouse-none")
         for _, s in ipairs(sources) do
             local source_type = obs.obs_source_get_id(s)
-            if dc_info and (allow_all_sources or source_type == dc_info.source_id) then
-                local name = obs.obs_source_get_name(s)
-                obs.obs_property_list_add_string(list, name, name)
-            elseif not dc_info and allow_all_sources then
+            if allow_all_sources or (dc_info and source_type == dc_info.source_id) then
                 local name = obs.obs_source_get_name(s)
                 obs.obs_property_list_add_string(list, name, name)
             end


### PR DESCRIPTION
Changes: 

- Added threshold check before updating crop filter (only calls OBS API if change > 0.5px)
- Throttled mouse position polling to 30ms instead of every frame
- Deferred scene item refresh by 150-200ms to avoid race conditions on startup
- Added retry logic for source size detection (fixes random init failures)
- Added compatibility wrappers for obs_sceneitem_get_info (handles API changes in newer OBS versions) 

Tested on: Windows 11, OBS Studio 32.0.2. The macOS and Linux changes are based on the existing FFI code patterns in the script     -- didn't change the actual platform logic, just added error handling and fallbacks.