### PR TITLE
Fix OBS 32+ API compatibility (replace deprecated sceneitem functions)

### DIFF
--- a/obs-zoom-to-mouse.lua
+++ b/obs-zoom-to-mouse.lua
@@ -448,7 +448,7 @@ function release_sceneitem()
 
         if sceneitem_info_orig ~= nil then
             log("Transform info reset back to original")
-            obs.obs_sceneitem_get_info(sceneitem, sceneitem_info_orig)
+            obs.obs_sceneitem_get_info2(sceneitem, sceneitem_info_orig)
             sceneitem_info_orig = nil
         end
 
@@ -574,13 +574,13 @@ function refresh_sceneitem(find_newest)
     if sceneitem ~= nil then
         -- Capture the original settings so we can restore them later
         sceneitem_info_orig = obs.obs_transform_info()
-        obs.obs_sceneitem_get_info(sceneitem, sceneitem_info_orig)
+        obs.obs_sceneitem_get_info2(sceneitem, sceneitem_info_orig)
 
         sceneitem_crop_orig = obs.obs_sceneitem_crop()
         obs.obs_sceneitem_get_crop(sceneitem, sceneitem_crop_orig)
 
         sceneitem_info = obs.obs_transform_info()
-        obs.obs_sceneitem_get_info(sceneitem, sceneitem_info)
+        obs.obs_sceneitem_get_info2(sceneitem, sceneitem_info)
 
         sceneitem_crop = obs.obs_sceneitem_crop()
         obs.obs_sceneitem_get_crop(sceneitem, sceneitem_crop)
@@ -631,7 +631,7 @@ function refresh_sceneitem(find_newest)
             sceneitem_info.bounds.x = source_width * sceneitem_info.scale.x
             sceneitem_info.bounds.y = source_height * sceneitem_info.scale.y
 
-            obs.obs_sceneitem_set_info(sceneitem, sceneitem_info)
+            obs.obs_sceneitem_set_info2(sceneitem, sceneitem_info)
 
             log("WARNING: Found existing non-boundingbox transform. This may cause issues with zooming.\n" ..
                 "         Settings have been auto converted to a bounding box scaling transfrom instead.\n" ..

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ An OBS lua script to zoom a display-capture source to focus on the mouse.
 
 I made this for my own use when recording videos as I wanted a way to zoom into my IDE when highlighting certain sections of code. My particular setup didn't seem to work very well with the existing zooming solutions so I created this.
 
-Built with OBS v29.1.3
+Built with OBS v32.0.4
 
 Now works on **Windows**, **Linux**, and **Mac**
 


### PR DESCRIPTION
This PR updates the script to ensure compatibility with OBS Studio 32+.

In OBS 32, the functions:
- obs_sceneitem_get_info
- obs_sceneitem_set_info

were replaced by:
- obs_sceneitem_get_info2
- obs_sceneitem_set_info2

The previous function calls result in a runtime error:
"attempt to call field 'obs_sceneitem_get_info' (a nil value)"

This change replaces the deprecated calls with the updated API equivalents.

Tested on:
- OBS Studio 32.0.4 (64-bit)
- Windows 10

The script works as expected after the update.

Please let me know if you would prefer a backward-compatible approach
to support both older and newer OBS versions.